### PR TITLE
fix(ci): use explicit version of zmk for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,4 +2,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3.0


### PR DESCRIPTION
Faced with the fact that the pipeline failed due to an error with qualifiers: `KeyError: 'qualifiers'.

As an option to fix the build, I decided to fix the version of the zmk repository and it helped.

Also found similar issue in zmk repo: https://github.com/zmkfirmware/zmk/issues/3274